### PR TITLE
Shorten critical path of the Int Mul/Div and FPU units

### DIFF
--- a/src_Core/CPU/FBox_Core.bsv
+++ b/src_Core/CPU/FBox_Core.bsv
@@ -133,10 +133,10 @@ endfunction
 (* synthesize *)
 module mkFBox_Core (FBox_Core_IFC);
 
-   FIFOF #(Token)          resetReqsF           <- mkFIFOF;
-   FIFOF #(Token)          resetRspsF           <- mkFIFOF;
+   FIFOF #(Token)          resetReqsF           <- mkFIFOF1;
+   FIFOF #(Token)          resetRspsF           <- mkFIFOF1;
 
-   FIFOF #(Bool)           frmFpuF              <- mkFIFOF;
+   FIFOF #(Bool)           frmFpuF              <- mkFIFOF1;
 
    Reg   #(FBoxState)      stateR               <- mkReg (FBOX_RST);
 

--- a/src_Core/CPU/FPU.bsv
+++ b/src_Core/CPU/FPU.bsv
@@ -46,14 +46,14 @@ module mkFPU ( FPU_IFC );
 
    Server#( Tuple4#(Maybe#(FDouble),FDouble,FDouble,RoundMode), FpuR ) fpu_madd   <- mkFloatingPointFusedMultiplyAccumulate;
 
-   FIFOF #(Token)          resetReqsF           <- mkFIFOF;
-   FIFOF #(Token)          resetRspsF           <- mkFIFOF;
+   FIFOF #(Token)          resetReqsF           <- mkFIFOF1;
+   FIFOF #(Token)          resetRspsF           <- mkFIFOF1;
 
-   FIFOF#( Fpu_Req )  iFifo        <- mkFIFOF; // TODO: bypass fifos?
-   FIFOF#( Fpu_Rsp )  oFifo        <- mkFIFOF; // TODO: bypass fifos?
-   FIFOF#( RoundMode ) rmdFifo     <- mkFIFOF; // TODO: bypass fifos?
-   FIFOF#( Bool )     isDoubleFifo <- mkFIFOF; // TODO: bypass fifos?
-   FIFOF#( Bool )     isNegateFifo <- mkFIFOF; // TODO: bypass fifos?
+   FIFOF#( Fpu_Req )  iFifo        <- mkFIFOF1; // TODO: bypass fifos?
+   FIFOF#( Fpu_Rsp )  oFifo        <- mkFIFOF1; // TODO: bypass fifos?
+   FIFOF#( RoundMode ) rmdFifo     <- mkFIFOF1; // TODO: bypass fifos?
+   FIFOF#( Bool )     isDoubleFifo <- mkFIFOF1; // TODO: bypass fifos?
+   FIFOF#( Bool )     isNegateFifo <- mkFIFOF1; // TODO: bypass fifos?
    Reg#(FpuR)         resWire      <- mkWire;
 
    function FDouble toDouble( FloatU x, RoundMode rmode );

--- a/src_Core/CPU/IntMulDiv.bsv
+++ b/src_Core/CPU/IntMulDiv.bsv
@@ -65,7 +65,7 @@ module mkIntDiv #(Reg #(Bit #(w)) rg_numer,    // a.k.a. dividend, and final rem
       rg_quo   <= rg_numer;
       rg_numer <= 0;         // remainder
       rg_state <= Div_DONE;
-      rg_done <= False;
+      rg_done <= True;
    endrule
 
    rule rl_start_s ((rg_state == Div_START) && (rg_denom != 0) && (! overflow));

--- a/src_Core/CPU/RISCV_MBox.bsv
+++ b/src_Core/CPU/RISCV_MBox.bsv
@@ -255,6 +255,7 @@ module mkRISCV_MBox (RISCV_MBox_IFC);
       // DIV, DIVU, REM, REMU
       else begin
 	 rg_state <= STATE_DIV_REM;
+	 rg_valid <= False;
 	 intDiv.start (is_signed, is_signed);
       end
    endmethod

--- a/src_SSITH_P2/xilinx_ip/component.xml
+++ b/src_SSITH_P2/xilinx_ip/component.xml
@@ -2337,6 +2337,10 @@
         <spirit:fileType>verilogSource</spirit:fileType>
       </spirit:file>
       <spirit:file>
+        <spirit:name>hdl/FIFO10.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
         <spirit:name>hdl/FIFO2.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
       </spirit:file>

--- a/src_SSITH_P2/xilinx_ip/hdl/FIFO10.v
+++ b/src_SSITH_P2/xilinx_ip/hdl/FIFO10.v
@@ -1,0 +1,134 @@
+
+// Copyright (c) 2000-2012 Bluespec, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// $Revision$
+// $Date$
+
+`ifdef BSV_ASSIGNMENT_DELAY
+`else
+  `define BSV_ASSIGNMENT_DELAY
+`endif
+
+`ifdef BSV_POSITIVE_RESET
+  `define BSV_RESET_VALUE 1'b1
+  `define BSV_RESET_EDGE posedge
+`else
+  `define BSV_RESET_VALUE 1'b0
+  `define BSV_RESET_EDGE negedge
+`endif
+
+
+`ifdef BSV_ASYNC_RESET
+ `define BSV_ARESET_EDGE_META or `BSV_RESET_EDGE RST
+`else
+ `define BSV_ARESET_EDGE_META
+`endif
+
+
+// Depth 1 FIFO data size 0!
+module FIFO10(CLK,
+              RST,
+              ENQ,
+              FULL_N,
+              DEQ,
+              EMPTY_N,
+              CLR
+              );
+
+   parameter guarded = 1;
+
+   input                  CLK;
+   input                  RST;
+   input                  ENQ;
+   input                  DEQ;
+   input                  CLR ;
+
+   output                 FULL_N;
+   output                 EMPTY_N;
+
+   reg                    empty_reg ;
+
+   assign                 EMPTY_N = empty_reg ;
+
+`ifdef BSV_NO_INITIAL_BLOCKS
+`else // not BSV_NO_INITIAL_BLOCKS
+   // synopsys translate_off
+   initial
+     begin
+        empty_reg = 1'b0;
+     end // initial begin
+   // synopsys translate_on
+`endif // BSV_NO_INITIAL_BLOCKS
+
+
+   assign FULL_N = !empty_reg;
+
+   always@(posedge CLK `BSV_ARESET_EDGE_META)
+     begin
+        if (RST == `BSV_RESET_VALUE)
+          begin
+             empty_reg <= `BSV_ASSIGNMENT_DELAY 1'b0;
+          end // if (RST == `BSV_RESET_VALUE)
+        else
+           begin
+              if (CLR)
+                begin
+                   empty_reg <= `BSV_ASSIGNMENT_DELAY 1'b0;
+                end
+              else if (ENQ)
+                begin
+                   empty_reg <= `BSV_ASSIGNMENT_DELAY 1'b1;
+                end
+              else if (DEQ)
+                begin
+                   empty_reg <= `BSV_ASSIGNMENT_DELAY 1'b0;
+                end // if (DEQ)
+           end // else: !if(RST == `BSV_RESET_VALUE)
+     end // always@ (posedge CLK or `BSV_RESET_EDGE RST)
+
+   // synopsys translate_off
+   always@(posedge CLK)
+     begin: error_checks
+        reg deqerror, enqerror ;
+
+        deqerror =  0;
+        enqerror = 0;
+        if (RST == ! `BSV_RESET_VALUE)
+           begin
+              if ( ! empty_reg && DEQ )
+                begin
+                   deqerror = 1 ;
+                   $display( "Warning: FIFO10: %m -- Dequeuing from empty fifo" ) ;
+                end
+              if ( ! FULL_N && ENQ && (!DEQ || guarded) )
+                begin
+                   enqerror =  1 ;
+                   $display( "Warning: FIFO10: %m -- Enqueuing to a full fifo" ) ;
+                end
+           end // if (RST == ! `BSV_RESET_VALUE)
+     end
+   // synopsys translate_on
+
+endmodule
+
+
+
+


### PR DESCRIPTION
 * Change code so that the valid output is in a single register bit
   * mkFIFOF1 instead of mkFIFO in the FPU
   * separate rg_valid in addition to rg_state